### PR TITLE
Lets have the page title as part of base template

### DIFF
--- a/themes/devsec/layouts/_default/baseof.html
+++ b/themes/devsec/layouts/_default/baseof.html
@@ -17,6 +17,9 @@
     <!-- End Nav -->
 
     <!-- Code that all your templates share, like a header -->
+    {{ if and (ne .File.Path "community.md") (ne .Section "baselines")  }}
+      {{ partial "page-header.html" . }}
+    {{ end }}
     {{ block "main" . }}
       <!-- The part of the page that begins to differ between templates -->
     {{ end }}

--- a/themes/devsec/layouts/blog/list.html
+++ b/themes/devsec/layouts/blog/list.html
@@ -1,12 +1,4 @@
 {{ define "main" }}
-<section id="page-header">
-  <div class="row">
-    <div class="large-12 medium-12 small-12 small-center columns">
-      <h2>News</h2>
-    </div>
-  </div>
-</section>
-
 <!-- merge internal and external content -->
 {{ $list := .Data.Pages  }}
 <section class="blog overview">

--- a/themes/devsec/layouts/page/project.html
+++ b/themes/devsec/layouts/page/project.html
@@ -1,9 +1,6 @@
 {{ define "main" }}
 <section class="contributing content">
     <div class="row">
-        <h1>{{ .Title }}</h1>
-    </div>
-    <div class="row">
         <div class="large-12 medium-12 small-12 small-center columns">
         {{ .Content }}
         </div>

--- a/themes/devsec/layouts/page/videos.html
+++ b/themes/devsec/layouts/page/videos.html
@@ -1,12 +1,4 @@
 {{ define "main" }}
-<section id="page-header">
-  <div class="row">
-    <div class="large-12 medium-12 small-12 small-center columns">
-      <h2>Videos</h2>
-    </div>
-  </div>
-</section>
-
 <section class="articles">
   <div class="row">
     <div class="large-12 medium-12 small-12 small-center columns">
@@ -22,5 +14,4 @@
     </div>
   </div>
 </section>
-
 {{ end }}

--- a/themes/devsec/layouts/partials/page-header.html
+++ b/themes/devsec/layouts/partials/page-header.html
@@ -1,0 +1,7 @@
+<section id="page-header">
+  <div class="row">
+    <div class="large-12 medium-12 small-12 small-center columns">
+      <h2>{{ .Title }}</h2>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
but avoid it for now for baseline and community sections. We would have to rework it later to match the layout.

Signed-off-by: Artem Sidorenko <artem@posteo.de>