### PR TITLE
Add RSS Link to the footer

### DIFF
--- a/themes/devsec/layouts/partials/footer.html
+++ b/themes/devsec/layouts/partials/footer.html
@@ -5,5 +5,5 @@
   <li><a href="https://galaxy.ansible.com/devsec/hardening">Ansible Galaxy</a></li>
   <li><a href="https://supermarket.getchef.com/cookbooks?q=hardening">Chef Community</a></li>
   <li><a href="https://forge.puppetlabs.com/hardening">Puppet Forge</a></li>
-  <li><a href="/blog/index.xml">RSS</a></li>
+  <li><a href="index.xml">RSS</a></li>
 </ul>

--- a/themes/devsec/layouts/partials/footer.html
+++ b/themes/devsec/layouts/partials/footer.html
@@ -5,4 +5,5 @@
   <li><a href="https://galaxy.ansible.com/devsec/hardening">Ansible Galaxy</a></li>
   <li><a href="https://supermarket.getchef.com/cookbooks?q=hardening">Chef Community</a></li>
   <li><a href="https://forge.puppetlabs.com/hardening">Puppet Forge</a></li>
+  <li><a href="/blog/index.xml">RSS</a></li>
 </ul>


### PR DESCRIPTION
Normally RSS links are always included in the footer. I have kept it that way here as well. But if you want the rss link to appear in the navigation bar, please let me know. Otherwise the rest of the links don't have icons on them, so I didn't do that with the RSS link.

Resolves #59 